### PR TITLE
Add query filtering.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 npm-debug.log
 doc/*.pdf
 src/build/*
+build/*
 *.gypi
 
 data/*

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "version": "0.0.7",
   "license": "MIT",
   "gypfile": true,
-  "engines": { "node": ">=4.0.0" },
+  "repository": "hobu/greyhound",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "bin": {
     "greyhound": "./src/forever.js"
   },
@@ -19,6 +22,7 @@
     "jade": "^1.11.0",
     "jsonminify": "^0.4.1",
     "less-middleware": "^1.0.4",
+    "lodash": "^4.16.2",
     "minimist": "^1.2.0",
     "morgan": "^1.6.1",
     "node-uuid": "^1.4.7",

--- a/src/controller.js
+++ b/src/controller.js
@@ -101,6 +101,7 @@ var console = require('clim')(),
         console.log('controller::read');
 
         var schema = query.schema;
+        var filter = query.filter;
         var compress =
             query.hasOwnProperty('compress') &&
             query.compress.toLowerCase() == 'true';
@@ -112,6 +113,7 @@ var console = require('clim')(),
 
         // Simplify our query decision tree for later.
         delete query.schema;
+        delete query.filter;
         delete query.compress;
         delete query.scale;
         delete query.offset;
@@ -123,7 +125,7 @@ var console = require('clim')(),
             var dataCb = (err, data, done) => onData(err, data, done);
 
             session.read(
-                schema, compress, scale, offset, query, initCb, dataCb);
+                schema, filter, compress, scale, offset, query, initCb, dataCb);
         });
     };
 

--- a/src/interfaces/http/static/views/httpView.jade
+++ b/src/interfaces/http/static/views/httpView.jade
@@ -3,7 +3,7 @@ html(lang="en")
     head
         title GREYHOUND WEB VIEWER
     link(rel="stylesheet" type="text/css" href="/css/style.css")
-    script(src="https://code.jquery.com/jquery-1.10.1.min.js")
+    script(src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js")
     script(src="/js/three.js")
     script(src="/js/Detector.js")
     script(src="/js/controls/TrackballControls.js")

--- a/src/interfaces/http/static/views/index.jade
+++ b/src/interfaces/http/static/views/index.jade
@@ -3,7 +3,7 @@ html(lang="en")
     head
         title GREYHOUND WEB VIEWER
     link(rel="stylesheet" type="text/css" href="/css/style.css")
-    script(src="https://code.jquery.com/jquery-1.10.1.min.js")
+    script(src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js")
     script(src="/js/three.js")
     script(src="/js/Detector.js")
     script(src="/js/controls/TrackballControls.js")

--- a/src/session/commands/read.hpp
+++ b/src/session/commands/read.hpp
@@ -30,6 +30,8 @@ public:
             double scale,
             const entwine::Point& offset,
             std::string schemaString,
+            std::string filterString,
+            uv_loop_t* loop,
             v8::UniquePersistent<v8::Function> initCb,
             v8::UniquePersistent<v8::Function> dataCb);
     virtual ~ReadCommand();
@@ -39,10 +41,12 @@ public:
             std::shared_ptr<Session> session,
             ItcBufferPool& itcBufferPool,
             std::string schemaString,
+            std::string filterString,
             bool compress,
             double scale,
             const entwine::Point& offset,
             v8::Local<v8::Object> query,
+            uv_loop_t* loop,
             v8::UniquePersistent<v8::Function> initCb,
             v8::UniquePersistent<v8::Function> dataCb);
 
@@ -92,9 +96,11 @@ protected:
     const double m_scale;
     const entwine::Point m_offset;
     entwine::Schema m_schema;
+    Json::Value m_filter;
     std::size_t m_numSent;
     std::shared_ptr<ReadQuery> m_readQuery;
 
+    uv_loop_t* m_loop;
     uv_async_t* m_initAsync;
     uv_async_t* m_dataAsync;
     v8::UniquePersistent<v8::Function> m_initCb;
@@ -131,9 +137,11 @@ public:
             double scale,
             const entwine::Point& offset,
             std::string schemaString,
+            std::string filterString,
             std::unique_ptr<entwine::Bounds> bounds,
             std::size_t depthBegin,
             std::size_t depthEnd,
+            uv_loop_t* loop,
             v8::UniquePersistent<v8::Function> initCb,
             v8::UniquePersistent<v8::Function> dataCb);
 

--- a/src/session/read-queries/base.cpp
+++ b/src/session/read-queries/base.cpp
@@ -27,8 +27,11 @@ void ReadQuery::read(ItcBuffer& buffer)
     buffer.resize(0);
     m_done = readSome(buffer);
 
-    std::cout << "Read " << buffer.size() << " bytes.  Done? " << m_done <<
-        std::endl;
+    if (buffer.size())
+    {
+        std::cout << "Read " << buffer.size() << " bytes.  Done? " << m_done <<
+            std::endl;
+    }
 
     if (compress())
     {

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -181,6 +181,7 @@ std::shared_ptr<ReadQuery> Session::query(
 
 std::shared_ptr<ReadQuery> Session::query(
         const entwine::Schema& schema,
+        const Json::Value& filter,
         const bool compress,
         const double scale,
         const entwine::Point& offset,
@@ -196,6 +197,7 @@ std::shared_ptr<ReadQuery> Session::query(
                     compress,
                     m_entwine->query(
                         schema,
+                        filter,
                         bounds ? *bounds : m_entwine->metadata().bounds(),
                         depthBegin,
                         depthEnd,

--- a/src/session/session.hpp
+++ b/src/session/session.hpp
@@ -64,6 +64,7 @@ public:
     // depths to search.
     std::shared_ptr<ReadQuery> query(
             const entwine::Schema& schema,
+            const Json::Value& filter,
             bool compress,
             double scale,
             const entwine::Point& offset,


### PR DESCRIPTION
This PR allows Mongo-style [comparison query operators](https://docs.mongodb.com/manual/reference/operator/query-comparison/) and [logical query operators](https://docs.mongodb.com/manual/reference/operator/query-logical/) to be passed to `read` requests to filter data.  Filters can apply arbitrarily nested logic to select points, and are passed via the `filter` query parameter.

An error handling case has also been improved, and a case that could cause streaming to hang has been fixed.

Samples:
Select a tile by its origin ID:

    filter={"Origin": 5}

Select a tile by a substring of its original path:

    filter={"Path":"tile-845.laz"}

Select multiple tiles with classification filter:

    filter={"Path":{"$in":["tile-845.laz", "tile-846.laz"]}, "Classification":{"$ne":18}}

Logical OR:

    filter={"$or":[
        {"Red":{"$gt":200}},
        {"Blue":{"$gt":120,"$lt":130}},
        {"Classification":{"$nin":[2,3]}}
    ]}