### PR TITLE
Add tile metadata API

### DIFF
--- a/doc/clientDevelopment.rst
+++ b/doc/clientDevelopment.rst
@@ -348,6 +348,69 @@ Bounds-overlap query
 
 File metadata may also be selected by querying for a ``bounds``, in which case all overlapping files from the input will be selected.  This query looks like ``/files?bounds=[100, 200, 300, 1100, 1200, 1300]`` or ``/files?bounds=[100, 200, 1100, 1200]``.  The format is ``[x-min, y-min, z-min, x-max, y-max, z-max]`` or ``[x-min, y-min, x-max, y-max]``.  Again, if only one match is found, then the result will be an object - if multiple matches are found, an array - and if zero, null.
 
+Results
+-------------------------------------------------------------------------------
+
+A single result may look something like this, edited for brevity ::
+
+    {
+        "bounds": [635648.8200000001, 851234.24, 411.09, 636357.77, 852448.12, 556.69],
+        "metadata": {
+            "comp_spatialreference": "...",
+            "compressed": true,
+            "count": 591852,
+            "creation_doy": 271,
+            "creation_year": 2016,
+            "dataformat_id": 3,
+            "dataoffset": 1812,
+            "filesource_id": 0,
+            "global_encoding": 0,
+            "global_encoding_base64": "AAA=",
+            "header_size": 227,
+            "major_version": 1,
+            "maxx": 636357.77,
+            "maxy": 852448.12,
+            "maxz": 556.69,
+            "minor_version": 2,
+            "minx": 635648.82,
+            "miny": 851234.24,
+            "minz": 411.09,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0,
+            "project_id": "00000000-0000-0000-0000-000000000000",
+            "scale_x": 0.01,
+            "scale_y": 0.01,
+            "scale_z": 0.01,
+            "software_id": "PDAL 1.3.0 (8a481e)",
+            "spatialreference": "...",
+            "srs": {
+                "compoundwkt": "...",
+                "horizontal": "...",
+                "isgeocentric": false,
+                "isgeographic": false,
+                "prettycompoundwkt": "...",
+                "prettywkt": "...",
+                "proj4": "+proj=lcc +lat_1=43 +lat_2=45.5 +lat_0=41.75 +lon_0=-120.5 +x_0=399999.9999999999 +y_0=0 +ellps=GRS80 +units=ft +no_defs",
+                "units": { "horizontal": "foot", "vertical": "" },
+                "vertical": "",
+                "wkt": "...",
+            },
+            "system_id": "PDAL",
+            "vlr_0": { "description": "http://laszip.org", "record_id": 22204, "user_id": "laszip encoded" },
+            "vlr_1": { ... },
+            "vlr_2": { ... }
+        },
+        "numPoints": 591852,
+        "origin": 1,
+        "path": "my-data/tile-10.laz",
+        "pointStats": { "inserts": 591852, "outOfBounds": 0, "overflows": 0 },
+        "srs": "...",
+        "status": "inserted"
+    }
+
+The ``metadata`` key is header metadata picked up by PDAL, so its contents are simply forwarded as-is.  Other keys are specific to Entwine's indexing.
+
 |
 
 Working with Greyhound

--- a/doc/clientDevelopment.rst
+++ b/doc/clientDevelopment.rst
@@ -33,6 +33,8 @@ Command Set
 +---------------+-------------------------------------------------------------+
 | hierarchy     | Get a metadata hierarchy with point counts information.     |
 +---------------+-------------------------------------------------------------+
+| files         | Get the metadata for files from the unindexed dataset.      |
++---------------+-------------------------------------------------------------+
 
 |
 
@@ -312,6 +314,39 @@ This result indicates that at depth 8, for the entire queried bounds, there are 
 At depth 9, for the north-east-down (``ned``) bisected bounds, which would be ``[500, 500, 0, 1000, 1000, 500]``, there are 138599 points.  For ``neu`` at depth 9, being ``[500, 500, 500, 1000, 1000, 1000]``, there are 13653 points.
 
 At depth 10, starting from the ``ned`` bounds, the ``neu`` bounds of ``[750, 750, 250, 1000, 1000, 500]`` contains 13064 points.  Since there is no key for ``["ned"]["ned"]``, there are zero points at depth 10 for bounds ``[750, 750, 0, 1000, 1000, 250]``.
+
+|
+
+The Files Query
+===============================================================================
+
+Description
+-------------------------------------------------------------------------------
+
+This query returns a JSON structure containing the original metadata found in the selected input files which make up an indexed dataset.  The metadata for a single file may be returned as an object, or if multiple files are selected, an array of objects.  Files may be selected by their filename, their location in the index, or by selecting those files which overlap a queried bounds.
+
+Single-selection form
+-------------------------------------------------------------------------------
+
+One form of the ``files`` query selects the metadata for a single file from the input of an index.  This selection is accomplished via a string portion of a file-path or a number specifying a unique sequence-location within the output index.
+
+The file-path selection looks like ``/files/my-input-tile-42.laz``.  In this case, a substring match will be performed against the string ``my-input-tile-42.laz``.  The input to the ``files`` query must be specific enough to select only the file desired.  For example, if a dataset were comprised of files ``abc-1.laz`` and ``abc-2.laz``, a query of ``/files/abc`` could return either of those files.
+
+A sequence-location selection looks like ``/files/2718``, which would select the file with an ``OriginId`` of ``2718``.  For each input file, every point from that file is assigned a unique ``OriginId`` dimension, so this query may be derived from the point data for a point received from a ``read`` query.
+
+If no match can be made for either a partial path or an ``OriginId`` value, then ``null`` will be returned.
+
+Query form
+-------------------------------------------------------------------------------
+
+The single-selection queries above may be alternatively made with a more flexible query-parameter format using the query parameter ``search``.  For the above examples, the corresponding queries would be ``/files?search=my-input-tile-42.laz`` and ``files?search=2718``.
+
+In addition to the single-selection form, this form may also accept an array containing multiple queries similar to the above.  Their types may be mixed, for example the array may contain both file paths as well as ``OriginId`` values.  For example, ``/files?search=["my-input-tile-42.laz", 2718]``.  The array must be valid JSON, so strings must be quoted.  For each entry in the input query, the output will contain one entry, which may be null if no matches were found for an input entry.  If the query is of size one, then the result will be an object (or null if there are no results).
+
+Bounds-overlap query
+-------------------------------------------------------------------------------
+
+File metadata may also be selected by querying for a ``bounds``, in which case all overlapping files from the input will be selected.  This query looks like ``/files?bounds=[100, 200, 300, 1100, 1200, 1300]`` or ``/files?bounds=[100, 200, 1100, 1200]``.  The format is ``[x-min, y-min, z-min, x-max, y-max, z-max]`` or ``[x-min, y-min, x-max, y-max]``.  Again, if only one match is found, then the result will be an object - if multiple matches are found, an array - and if zero, null.
 
 |
 


### PR DESCRIPTION
Add API to fetch metadata information related to the input files of a dataset.  Using queries like `/files/4`, `/files/tile-42.laz`, `/files?search=["tile-42.laz", "tile-43.laz", 314, 315]`, or `files?bounds=[400, 400, 0, 600, 800, 200]`, the metadata tree captured by PDAL as well as some of Entwine's indexing metadata can be inspected.

The integer queries use the `OriginId` dimension inserted by Entwine, meaning that a point selection UI from a client (for example a visualizer) can display the upstream file metadata for a selected point by querying `/files` API with the `OriginId` value from the selected point.

With this capability, along with the `filter` capability for `read` queries, clients can identify the input tiles contributing to a region of interest, view their metadata, and then either go back to the original input tiles directly or reconstruct the tile data from Greyhound querying.  For Greyhound reconstruction the [PDAL Greyhound reader](http://www.pdal.io/stages/readers.greyhound.html) may be used.